### PR TITLE
39 better signer key

### DIFF
--- a/src/interfaces/IECDSAStakeRegistry.sol
+++ b/src/interfaces/IECDSAStakeRegistry.sol
@@ -253,6 +253,26 @@ interface IECDSAStakeRegistry is
     ) external view returns (bool);
 
     /*
+     * @notice Retrieves the latest operator address associated with a signing key.
+     * @param signingKey The signing key to look up.
+     * @return The latest operator address associated with the signing key, or address(0) if none.
+     */
+    function getLatestOperatorForSigningKey(
+        address signingKey
+    ) external view returns (address);
+
+    /*
+     * @notice Retrieves the operator address associated with a signing key at a specific block.
+     * @param signingKey The signing key to look up.
+     * @param blockNumber The block number to query at.
+     * @return The operator address associated with the signing key at the given block, or address(0) if none.
+     */
+    function getOperatorForSigningKeyAtBlock(
+        address signingKey,
+        uint256 blockNumber
+    ) external view returns (address);
+
+    /*
      * @notice Returns the minimum weight required for operator participation.
      * @return The minimum weight threshold.
      */

--- a/src/interfaces/IECDSAStakeRegistry.sol
+++ b/src/interfaces/IECDSAStakeRegistry.sol
@@ -40,6 +40,8 @@ interface IECDSAStakeRegistryErrors {
     error OperatorAlreadyRegistered();
     /// @notice Thrown when de-registering or updating the stake for an unregisted operator.
     error OperatorNotRegistered();
+    /// @notice Thrown when validating a signature by a signer which is not associated with any operator for that block.
+    error SignerNotRegistered();
 }
 
 interface IECDSAStakeRegistryTypes {

--- a/src/interfaces/IECDSAStakeRegistry.sol
+++ b/src/interfaces/IECDSAStakeRegistry.sol
@@ -42,6 +42,8 @@ interface IECDSAStakeRegistryErrors {
     error OperatorNotRegistered();
     /// @notice Thrown when validating a signature by a signer which is not associated with any operator for that block.
     error SignerNotRegistered();
+    /// @notice Thrown when attempting to update to a signing key that's already in use by another operator.
+    error SigningKeyAlreadyInUse();
 }
 
 interface IECDSAStakeRegistryTypes {

--- a/src/interfaces/IECDSAStakeRegistry.sol
+++ b/src/interfaces/IECDSAStakeRegistry.sol
@@ -224,6 +224,27 @@ interface IECDSAStakeRegistry is
         uint256 blockNumber
     ) external view returns (address);
 
+
+    /*
+     * @notice Retrieves the latest operator address associated with a signing key.
+     * @param signingKey The address of the signing key.
+     * @return The latest operator address associated with the signing key, or address(0) if none.
+     */
+    function getLatestOperatorForSigningKey(
+        address signingKey
+    ) external view returns (address);
+
+    /*
+     * @notice Retrieves the operator address associated with a signing key at a specific block.
+     * @param signingKey The address of the signing key.
+     * @param blockNumber The block number to query at.
+     * @return The operator address associated with the signing key at the given block, or address(0) if none.
+     */
+    function getOperatorForSigningKeyAtBlock(
+        address signingKey,
+        uint256 blockNumber
+    ) external view returns (address);
+
     /*
      * @notice Retrieves the last recorded weight for a given operator.
      * @param operator The address of the operator.
@@ -253,26 +274,6 @@ interface IECDSAStakeRegistry is
     function operatorRegistered(
         address operator
     ) external view returns (bool);
-
-    /*
-     * @notice Retrieves the latest operator address associated with a signing key.
-     * @param signingKey The signing key to look up.
-     * @return The latest operator address associated with the signing key, or address(0) if none.
-     */
-    function getLatestOperatorForSigningKey(
-        address signingKey
-    ) external view returns (address);
-
-    /*
-     * @notice Retrieves the operator address associated with a signing key at a specific block.
-     * @param signingKey The signing key to look up.
-     * @param blockNumber The block number to query at.
-     * @return The operator address associated with the signing key at the given block, or address(0) if none.
-     */
-    function getOperatorForSigningKeyAtBlock(
-        address signingKey,
-        uint256 blockNumber
-    ) external view returns (address);
 
     /*
      * @notice Returns the minimum weight required for operator participation.

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -202,7 +202,7 @@ contract ECDSAStakeRegistry is
     function getLatestOperatorForSigningKey(
         address signingKey
     ) external view returns (address) {
-        return address(uint160(_signingKeyToOperator[signingKey].latest()));
+        return address(uint160(_signingKeyToOperatorHistory[signingKey].latest()));
     }
 
     /// @inheritdoc IECDSAStakeRegistry
@@ -210,7 +210,7 @@ contract ECDSAStakeRegistry is
         address signingKey,
         uint256 blockNumber
     ) external view returns (address) {
-        return address(uint160(_signingKeyToOperator[signingKey].getAtBlock(blockNumber)));
+        return address(uint160(_signingKeyToOperatorHistory[signingKey].getAtBlock(blockNumber)));
     }
 
     /// @inheritdoc IECDSAStakeRegistry
@@ -343,7 +343,7 @@ contract ECDSAStakeRegistry is
             revert OperatorAlreadyRegistered();
         }
         // Check if the signing key is already in use by another operator
-        address existingOperator = address(uint160(_signingKeyToOperator[signingKey].latest()));
+        address existingOperator = address(uint160(_signingKeyToOperatorHistory[signingKey].latest()));
         if (existingOperator != address(0)) {
             revert SigningKeyAlreadyInUse();
         }
@@ -366,10 +366,10 @@ contract ECDSAStakeRegistry is
         }
         // Remove the old signing key from the mapping if it exists
         if (oldSigningKey != address(0)) {
-            _signingKeyToOperator[oldSigningKey].push(uint160(0));
+            _signingKeyToOperatorHistory[oldSigningKey].push(uint160(0));
         }
         // Update the new signing key to point to this operator
-        _signingKeyToOperator[newSigningKey].push(uint160(operator));
+        _signingKeyToOperatorHistory[newSigningKey].push(uint160(operator));
         _operatorSigningKeyHistory[operator].push(uint160(newSigningKey));
         emit SigningKeyUpdate(operator, block.number, newSigningKey, oldSigningKey);
     }
@@ -444,32 +444,38 @@ contract ECDSAStakeRegistry is
     /**
      * @notice Common logic to verify a batch of ECDSA signatures against a hash, using either last stake weight or at a specific block.
      * @param digest The hash of the data the signers endorsed.
-     * @param operators A collection of addresses that endorsed the data hash.
+     * @param signers A collection of signing key addresses that endorsed the data hash.
      * @param signatures A collection of signatures matching the signers.
      * @param referenceBlock The block number for evaluating stake weight; use max uint32 for latest weight.
      */
     function _checkSignatures(
         bytes32 digest,
-        address[] memory operators,
+        address[] memory signers,
         bytes[] memory signatures,
         uint32 referenceBlock
     ) internal view {
-        uint256 signersLength = operators.length;
-        address currentOperator;
-        address lastOperator;
-        address signer;
+        uint256 signersLength = signers.length;
+        address currentSigner;
+        address lastSigner;
+        address operator;
         uint256 signedWeight;
-
+        
         _validateSignaturesLength(signersLength, signatures.length);
         for (uint256 i; i < signersLength; i++) {
-            currentOperator = operators[i];
-            signer = _getOperatorSigningKey(currentOperator, referenceBlock);
-
-            _validateSortedSigners(lastOperator, currentOperator);
-            _validateSignature(signer, digest, signatures[i]);
-
-            lastOperator = currentOperator;
-            uint256 operatorWeight = _getOperatorWeight(currentOperator, referenceBlock);
+            currentSigner = signers[i];
+            operator = _getOperatorForSigningKey(currentSigner, referenceBlock);
+            if (operator == address(0)) {
+                revert SignerNotRegistered();
+            }
+            if (!_operatorRegistered[operator]) {
+                revert OperatorNotRegistered();
+            }
+            
+            _validateSortedSigners(lastSigner, currentSigner);
+            _validateSignature(currentSigner, digest, signatures[i]);
+            
+            lastSigner = currentSigner;
+            uint256 operatorWeight = _getOperatorWeight(operator, referenceBlock);
             signedWeight += operatorWeight;
         }
 
@@ -526,6 +532,20 @@ contract ECDSAStakeRegistry is
             revert InvalidReferenceBlock();
         }
         return address(uint160(_operatorSigningKeyHistory[operator].getAtBlock(referenceBlock)));
+    }
+
+    /// @notice Retrieves the operator weight for a signer, either at the last checkpoint or a specified block.
+    /// @param signingKey The signing key to query their operator history for
+    /// @param referenceBlock The block number to query the operator's weight at, or the maximum uint32 value for the last checkpoint.
+    /// @return The operator registered for this signing key, or address(0) if none
+    function _getOperatorForSigningKey(
+        address signingKey,
+        uint32 referenceBlock
+    ) internal view returns (address) {
+        if (referenceBlock >= block.number) {
+            revert InvalidReferenceBlock();
+        }
+        return address(uint160(_signingKeyToOperatorHistory[signingKey].getAtBlock(referenceBlock)));
     }
 
     /// @notice Retrieves the operator weight for a signer, either at the last checkpoint or a specified block.

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -330,9 +330,6 @@ contract ECDSAStakeRegistry is
         emit OperatorDeregistered(operator, address(_serviceManager));
     }
 
-    /// @notice Error thrown when attempting to register with a signing key that's already in use
-    error SigningKeyAlreadyInUse();
-
     /// @dev registers an operator through a provided signature
     /// @param operatorSignature Contains the operator's signature, salt, and expiry
     /// @param signingKey The signing key to add to the operator's history
@@ -366,6 +363,13 @@ contract ECDSAStakeRegistry is
         if (newSigningKey == oldSigningKey) {
             return;
         }
+
+        // Check if the new signing key is already in use by another operator
+        address existingOperator = address(uint160(_signingKeyToOperatorHistory[newSigningKey].latest()));
+        if (existingOperator != address(0) && existingOperator != operator) {
+            revert SigningKeyAlreadyInUse();
+        }
+
         // Remove the old signing key from the mapping if it exists
         if (oldSigningKey != address(0)) {
             _signingKeyToOperatorHistory[oldSigningKey].push(uint160(0));

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -322,6 +322,8 @@ contract ECDSAStakeRegistry is
         }
         _totalOperators--;
         delete _operatorRegistered[operator];
+        address signingKey = _getLatestOperatorSigningKey(operator);
+        _signingKeyToOperatorHistory[signingKey].push(uint160(0));
         int256 delta = _updateOperatorWeight(operator);
         _updateTotalWeight(delta);
         IServiceManager(_serviceManager).deregisterOperatorFromAVS(operator);
@@ -533,6 +535,16 @@ contract ECDSAStakeRegistry is
         }
         return address(uint160(_operatorSigningKeyHistory[operator].getAtBlock(referenceBlock)));
     }
+
+    /// @notice Retrieves the operator weight for a signer, either at the last checkpoint or a specified block.
+    /// @param operator The operator to query their signing key history for
+    /// @return The latest signing key for this operator.
+    function _getLatestOperatorSigningKey(
+        address operator
+    ) internal view returns (address) {
+        return address(uint160(_operatorSigningKeyHistory[operator].latest()));
+    }
+
 
     /// @notice Retrieves the operator weight for a signer, either at the last checkpoint or a specified block.
     /// @param signingKey The signing key to query their operator history for

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -199,6 +199,21 @@ contract ECDSAStakeRegistry is
     }
 
     /// @inheritdoc IECDSAStakeRegistry
+    function getLatestOperatorForSigningKey(
+        address signingKey
+    ) external view returns (address) {
+        return address(uint160(_signingKeyToOperator[signingKey].latest()));
+    }
+
+    /// @inheritdoc IECDSAStakeRegistry
+    function getOperatorForSigningKeyAtBlock(
+        address signingKey,
+        uint256 blockNumber
+    ) external view returns (address) {
+        return address(uint160(_signingKeyToOperator[signingKey].getAtBlock(blockNumber)));
+    }
+
+    /// @inheritdoc IECDSAStakeRegistry
     function minimumWeight() external view returns (uint256) {
         return _minimumWeight;
     }
@@ -313,6 +328,9 @@ contract ECDSAStakeRegistry is
         emit OperatorDeregistered(operator, address(_serviceManager));
     }
 
+    /// @notice Error thrown when attempting to register with a signing key that's already in use
+    error SigningKeyAlreadyInUse();
+
     /// @dev registers an operator through a provided signature
     /// @param operatorSignature Contains the operator's signature, salt, and expiry
     /// @param signingKey The signing key to add to the operator's history
@@ -323,6 +341,11 @@ contract ECDSAStakeRegistry is
     ) internal virtual {
         if (_operatorRegistered[operator]) {
             revert OperatorAlreadyRegistered();
+        }
+        // Check if the signing key is already in use by another operator
+        address existingOperator = address(uint160(_signingKeyToOperator[signingKey].latest()));
+        if (existingOperator != address(0)) {
+            revert SigningKeyAlreadyInUse();
         }
         _totalOperators++;
         _operatorRegistered[operator] = true;
@@ -341,6 +364,12 @@ contract ECDSAStakeRegistry is
         if (newSigningKey == oldSigningKey) {
             return;
         }
+        // Remove the old signing key from the mapping if it exists
+        if (oldSigningKey != address(0)) {
+            _signingKeyToOperator[oldSigningKey].push(uint160(0));
+        }
+        // Update the new signing key to point to this operator
+        _signingKeyToOperator[newSigningKey].push(uint160(operator));
         _operatorSigningKeyHistory[operator].push(uint160(newSigningKey));
         emit SigningKeyUpdate(operator, block.number, newSigningKey, oldSigningKey);
     }

--- a/src/unaudited/ECDSAStakeRegistry.sol
+++ b/src/unaudited/ECDSAStakeRegistry.sol
@@ -469,9 +469,6 @@ contract ECDSAStakeRegistry is
             if (operator == address(0)) {
                 revert SignerNotRegistered();
             }
-            if (!_operatorRegistered[operator]) {
-                revert OperatorNotRegistered();
-            }
             
             _validateSortedSigners(lastSigner, currentSigner);
             _validateSignature(currentSigner, digest, signatures[i]);
@@ -536,7 +533,7 @@ contract ECDSAStakeRegistry is
         return address(uint160(_operatorSigningKeyHistory[operator].getAtBlock(referenceBlock)));
     }
 
-    /// @notice Retrieves the operator weight for a signer, either at the last checkpoint or a specified block.
+    /// @notice Retrieves the latest signing key for a given operator.
     /// @param operator The operator to query their signing key history for
     /// @return The latest signing key for this operator.
     function _getLatestOperatorSigningKey(
@@ -546,9 +543,9 @@ contract ECDSAStakeRegistry is
     }
 
 
-    /// @notice Retrieves the operator weight for a signer, either at the last checkpoint or a specified block.
+    /// @notice Retrieves the operator address for a signer, either at the last checkpoint or a specified block.
     /// @param signingKey The signing key to query their operator history for
-    /// @param referenceBlock The block number to query the operator's weight at, or the maximum uint32 value for the last checkpoint.
+    /// @param referenceBlock The block number to query the operator's address at, or block.number-1 for the last checkpoint.
     /// @return The operator registered for this signing key, or address(0) if none
     function _getOperatorForSigningKey(
         address signingKey,

--- a/src/unaudited/ECDSAStakeRegistryStorage.sol
+++ b/src/unaudited/ECDSAStakeRegistryStorage.sol
@@ -46,6 +46,9 @@ abstract contract ECDSAStakeRegistryStorage is IECDSAStakeRegistry {
     /// @notice Maps an operator to their registration status
     mapping(address => bool) internal _operatorRegistered;
 
+    /// @notice Maps a signing key to its operator address
+    mapping(address => CheckpointsUpgradeable.History) internal _signingKeyToOperator;
+
     /// @param _delegationManager Connects this registry with the DelegationManager
     constructor(
         IDelegationManager _delegationManager

--- a/src/unaudited/ECDSAStakeRegistryStorage.sol
+++ b/src/unaudited/ECDSAStakeRegistryStorage.sol
@@ -46,8 +46,8 @@ abstract contract ECDSAStakeRegistryStorage is IECDSAStakeRegistry {
     /// @notice Maps an operator to their registration status
     mapping(address => bool) internal _operatorRegistered;
 
-    /// @notice Maps a signing key to its operator address
-    mapping(address => CheckpointsUpgradeable.History) internal _signingKeyToOperator;
+    /// @notice Maps a signing key to its operator address history
+    mapping(address => CheckpointsUpgradeable.History) internal _signingKeyToOperatorHistory;
 
     /// @param _delegationManager Connects this registry with the DelegationManager
     constructor(

--- a/test/unit/ECDSAStakeRegistryEqualWeightUnit.t.sol
+++ b/test/unit/ECDSAStakeRegistryEqualWeightUnit.t.sol
@@ -19,6 +19,10 @@ import {ECDSAStakeRegistryEqualWeight} from
 
 contract EqualWeightECDSARegistry is ECDSAStakeRegistrySetup {
     ECDSAStakeRegistryEqualWeight internal fixedWeightRegistry;
+    
+    // Test signing keys
+    address internal constant SIGNING_KEY_1 = address(0x1001);
+    address internal constant SIGNING_KEY_2 = address(0x1002);
 
     function setUp() public virtual override {
         super.setUp();
@@ -32,12 +36,11 @@ contract EqualWeightECDSARegistry is ECDSAStakeRegistrySetup {
 
         fixedWeightRegistry.permitOperator(operator1);
         fixedWeightRegistry.permitOperator(operator2);
-        address operator = address(0x123);
         ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
         vm.prank(operator1);
-        fixedWeightRegistry.registerOperatorWithSignature(operatorSignature, operator1);
+        fixedWeightRegistry.registerOperatorWithSignature(operatorSignature, SIGNING_KEY_1);
         vm.prank(operator2);
-        fixedWeightRegistry.registerOperatorWithSignature(operatorSignature, operator2);
+        fixedWeightRegistry.registerOperatorWithSignature(operatorSignature, SIGNING_KEY_2);
     }
 
     function test_FixedStakeUpdates() public {
@@ -54,10 +57,9 @@ contract EqualWeightECDSARegistry is ECDSAStakeRegistrySetup {
         assertEq(fixedWeightRegistry.getLastCheckpointTotalWeight(), 1);
 
         vm.roll(block.number + 1);
-        address operator = address(0x123);
         ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
         vm.prank(operator1);
-        fixedWeightRegistry.registerOperatorWithSignature(operatorSignature, operator1);
+        fixedWeightRegistry.registerOperatorWithSignature(operatorSignature, SIGNING_KEY_1);
 
         assertEq(fixedWeightRegistry.getLastCheckpointOperatorWeight(operator1), 1);
         assertEq(fixedWeightRegistry.getLastCheckpointOperatorWeight(operator2), 1);

--- a/test/unit/ECDSAStakeRegistryPermissionedUnit.t.sol
+++ b/test/unit/ECDSAStakeRegistryPermissionedUnit.t.sol
@@ -20,6 +20,11 @@ import {ECDSAStakeRegistryPermissioned} from
 
 contract PermissionedECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
     ECDSAStakeRegistryPermissioned internal permissionedRegistry;
+    
+    // Test signing keys
+    address internal constant SIGNING_KEY_1 = address(0x1001);
+    address internal constant SIGNING_KEY_2 = address(0x1002);
+    address internal constant SIGNING_KEY_3 = address(0x1003);
 
     function setUp() public virtual override {
         super.setUp();
@@ -35,9 +40,9 @@ contract PermissionedECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
         permissionedRegistry.permitOperator(operator2);
         ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
         vm.prank(operator1);
-        permissionedRegistry.registerOperatorWithSignature(operatorSignature, operator1);
+        permissionedRegistry.registerOperatorWithSignature(operatorSignature, SIGNING_KEY_1);
         vm.prank(operator2);
-        permissionedRegistry.registerOperatorWithSignature(operatorSignature, operator1);
+        permissionedRegistry.registerOperatorWithSignature(operatorSignature, SIGNING_KEY_2);
     }
 
     function test_RevertsWhen_NotOwner_PermitOperator() public {
@@ -104,16 +109,18 @@ contract PermissionedECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
         address operator3 = address(0xBEEF);
         permissionedRegistry.permitOperator(operator3);
         ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+        address signingKey3 = address(0x1003);
         vm.prank(operator3);
-        permissionedRegistry.registerOperatorWithSignature(operatorSignature, operator3);
+        permissionedRegistry.registerOperatorWithSignature(operatorSignature, signingKey3);
     }
 
     function test_DeregisterOperator() public {
         address operator3 = address(0xBEEF);
         permissionedRegistry.permitOperator(operator3);
         ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+        address signingKey3 = address(0x1003);
         vm.prank(operator3);
-        permissionedRegistry.registerOperatorWithSignature(operatorSignature, operator3);
+        permissionedRegistry.registerOperatorWithSignature(operatorSignature, signingKey3);
 
         vm.prank(operator3);
         permissionedRegistry.deregisterOperator();

--- a/test/unit/ECDSAStakeRegistryUnit.t.sol
+++ b/test/unit/ECDSAStakeRegistryUnit.t.sol
@@ -999,6 +999,46 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
         newRegistry.registerOperatorWithSignature(operatorSignature, sharedSigningKey);
     }
     
+    function test_RevertsWhen_UpdateToDuplicateSigningKey() public {
+        // Create a new registry instance for this test to avoid conflicts with the setup
+        IStrategy mockStrategy = IStrategy(address(0x1234));
+        IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({
+            strategies: new IECDSAStakeRegistryTypes.StrategyParams[](1)
+        });
+        quorum.strategies[0] = 
+            IECDSAStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 10000});
+        ECDSAStakeRegistry newRegistry = new ECDSAStakeRegistry(IDelegationManager(address(mockDelegationManager)));
+        newRegistry.initialize(address(mockServiceManager), 100, quorum);
+        
+        // Create two different operators with different initial signing keys
+        address operator1Address = address(0xABCD);
+        address operator2Address = address(0xDCBA);
+        address operator1SigningKey = address(0x1111);
+        address operator2SigningKey = address(0x2222);
+        
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+
+        // Register both operators with different signing keys
+        vm.prank(operator1Address);
+        newRegistry.registerOperatorWithSignature(operatorSignature, operator1SigningKey);
+        
+        vm.prank(operator2Address);
+        newRegistry.registerOperatorWithSignature(operatorSignature, operator2SigningKey);
+        
+        // Try to update operator2's signing key to operator1's signing key
+        // This should revert with SigningKeyAlreadyInUse
+        vm.prank(operator2Address);
+        vm.expectRevert(abi.encodeWithSignature("SigningKeyAlreadyInUse()"));
+        newRegistry.updateOperatorSigningKey(operator1SigningKey);
+        
+        // Verify that operator2's signing key is still the original one
+        assertEq(
+            newRegistry.getLatestOperatorForSigningKey(operator2SigningKey),
+            operator2Address,
+            "Operator 2 should still be registered with the original signing key"
+        );
+    }
+    
     function test_ReuseSigningKeyAfterUpdate() public {
         // Create a new registry instance for this test to avoid conflicts with the setup
         IStrategy mockStrategy = IStrategy(address(0x1234));

--- a/test/unit/ECDSAStakeRegistryUnit.t.sol
+++ b/test/unit/ECDSAStakeRegistryUnit.t.sol
@@ -836,6 +836,232 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
         registry.isValidSignature(dataHash, abi.encode(operators, signatures, referenceBlock));
     }
 
+    function test_GetOperatorForSigningKey_AfterRegistration() public {
+        // Create a new operator and signing key
+        address operator = operator3;
+        address signingKey = signer;
+
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+
+        // Register operator with the signing key
+        vm.prank(operator);
+        registry.registerOperatorWithSignature(operatorSignature, signingKey);
+
+        // Query the operator by signing key
+        address retrievedOperator = registry.getLatestOperatorForSigningKey(signingKey);
+
+        // Verify that the retrieved operator matches the registered operator
+        assertEq(
+            retrievedOperator,
+            operator,
+            "The retrieved operator does not match the registered operator"
+        );
+    }
+
+    function test_GetOperatorForSigningKey_NonRegisteredKey() public {
+        // Use a signing key that has never been registered
+        address nonRegisteredKey = address(vm.addr(999));
+
+        // Query the operator by the non-registered signing key
+        address retrievedOperator = registry.getLatestOperatorForSigningKey(nonRegisteredKey);
+
+        // Verify that the retrieved operator is the zero address
+        assertEq(
+            retrievedOperator,
+            address(0),
+            "The retrieved operator should be the zero address for a non-registered signing key"
+        );
+    }
+
+    function test_GetOperatorForSigningKey_AfterUpdate() public {
+        // Create a new operator and signing keys
+        address operator = operator3;
+        address initialSigningKey = signer;
+        address updatedSigningKey = address(vm.addr(signerPk + 1));
+
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+
+        // Register operator with the initial signing key
+        vm.prank(operator);
+        registry.registerOperatorWithSignature(operatorSignature, initialSigningKey);
+
+        // Update the operator's signing key
+        vm.prank(operator);
+        registry.updateOperatorSigningKey(updatedSigningKey);
+
+        // Query the operator by the updated signing key
+        address retrievedOperator = registry.getLatestOperatorForSigningKey(updatedSigningKey);
+
+        // Verify that the retrieved operator matches the registered operator
+        assertEq(
+            retrievedOperator,
+            operator,
+            "The retrieved operator does not match the registered operator after key update"
+        );
+    }
+
+    function test_GetOperatorForSigningKey_OldKeyAfterUpdate() public {
+        // Create a new operator and signing keys
+        address operator = operator3;
+        address initialSigningKey = signer;
+        address updatedSigningKey = address(vm.addr(signerPk + 1));
+
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+
+        // Register operator with the initial signing key
+        vm.prank(operator);
+        registry.registerOperatorWithSignature(operatorSignature, initialSigningKey);
+        
+        // Save the current block number
+        uint256 initialBlock = block.number;
+        vm.roll(block.number + 10);
+
+        // Update the operator's signing key
+        vm.prank(operator);
+        registry.updateOperatorSigningKey(updatedSigningKey);
+
+        // Query the operator by the old signing key (should return zero address for latest)
+        address retrievedOperator = registry.getLatestOperatorForSigningKey(initialSigningKey);
+
+        // Verify that the retrieved operator is the zero address
+        assertEq(
+            retrievedOperator,
+            address(0),
+            "The retrieved operator should be the zero address for an old signing key"
+        );
+    }
+
+    function test_GetOperatorForSigningKeyAtBlock_OldKey() public {
+        // Create a new operator and signing keys
+        address operator = operator3;
+        address initialSigningKey = signer;
+        address updatedSigningKey = address(vm.addr(signerPk + 1));
+
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+
+        // Register operator with the initial signing key
+        vm.prank(operator);
+        registry.registerOperatorWithSignature(operatorSignature, initialSigningKey);
+        
+        // Save the current block number
+        uint256 initialBlock = block.number;
+        vm.roll(block.number + 10);
+
+        // Update the operator's signing key
+        vm.prank(operator);
+        registry.updateOperatorSigningKey(updatedSigningKey);
+
+        // Query the operator by the old signing key at the old block
+        address retrievedOperator = registry.getOperatorForSigningKeyAtBlock(initialSigningKey, initialBlock);
+
+        // Verify that the retrieved operator matches the registered operator
+        assertEq(
+            retrievedOperator,
+            operator,
+            "The retrieved operator should match the original operator when querying at the old block"
+        );
+    }
+
+    function test_RevertsWhen_DuplicateSigningKey() public {
+        // Create a new registry instance for this test to avoid conflicts with the setup
+        IStrategy mockStrategy = IStrategy(address(0x1234));
+        IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({
+            strategies: new IECDSAStakeRegistryTypes.StrategyParams[](1)
+        });
+        quorum.strategies[0] = 
+            IECDSAStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 10000});
+        ECDSAStakeRegistry newRegistry = new ECDSAStakeRegistry(IDelegationManager(address(mockDelegationManager)));
+        newRegistry.initialize(address(mockServiceManager), 100, quorum);
+        
+        // Create two different operators
+        address operator1Address = address(0xABCD);
+        address operator2Address = address(0xDCBA);
+        // Same signing key for both operators
+        address sharedSigningKey = address(0x1111);
+
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+
+        // Register first operator with the signing key
+        vm.prank(operator1Address);
+        newRegistry.registerOperatorWithSignature(operatorSignature, sharedSigningKey);
+
+        // Try to register second operator with the same signing key
+        // This should now revert with SigningKeyAlreadyInUse
+        vm.prank(operator2Address);
+        vm.expectRevert(abi.encodeWithSignature("SigningKeyAlreadyInUse()"));
+        newRegistry.registerOperatorWithSignature(operatorSignature, sharedSigningKey);
+    }
+    
+    function test_ReuseSigningKeyAfterUpdate() public {
+        // Create a new registry instance for this test to avoid conflicts with the setup
+        IStrategy mockStrategy = IStrategy(address(0x1234));
+        IECDSAStakeRegistryTypes.Quorum memory quorum = IECDSAStakeRegistryTypes.Quorum({
+            strategies: new IECDSAStakeRegistryTypes.StrategyParams[](1)
+        });
+        quorum.strategies[0] = 
+            IECDSAStakeRegistryTypes.StrategyParams({strategy: mockStrategy, multiplier: 10000});
+        ECDSAStakeRegistry newRegistry = new ECDSAStakeRegistry(IDelegationManager(address(mockDelegationManager)));
+        newRegistry.initialize(address(mockServiceManager), 100, quorum);
+        
+        // Create two different operators
+        address operator1Address = address(0xABCD);
+        address operator2Address = address(0xDCBA);
+        
+        // Two different signing keys
+        address signingKey1 = address(0x1111);
+        address signingKey2 = address(0x2222);
+
+        ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
+
+        // Step 1: Register operator1 with signingKey1
+        vm.prank(operator1Address);
+        newRegistry.registerOperatorWithSignature(operatorSignature, signingKey1);
+        
+        // Verify operator1 is associated with signingKey1
+        assertEq(
+            newRegistry.getLatestOperatorForSigningKey(signingKey1),
+            operator1Address,
+            "operator1 should be associated with signingKey1"
+        );
+        
+        // Step 2: Update operator1's signing key to signingKey2
+        vm.prank(operator1Address);
+        newRegistry.updateOperatorSigningKey(signingKey2);
+        
+        // Verify operator1 is now associated with signingKey2
+        assertEq(
+            newRegistry.getLatestOperatorForSigningKey(signingKey2),
+            operator1Address,
+            "operator1 should be associated with signingKey2 after update"
+        );
+        
+        // Verify signingKey1 is no longer associated with any operator
+        assertEq(
+            newRegistry.getLatestOperatorForSigningKey(signingKey1),
+            address(0),
+            "signingKey1 should not be associated with any operator after update"
+        );
+        
+        // Step 3: Register operator2 with signingKey1 (which should be allowed now)
+        vm.prank(operator2Address);
+        newRegistry.registerOperatorWithSignature(operatorSignature, signingKey1);
+        
+        // Step 4: Verify the final associations
+        // signingKey2 should point to operator1
+        assertEq(
+            newRegistry.getLatestOperatorForSigningKey(signingKey2),
+            operator1Address,
+            "signingKey2 should point to operator1"
+        );
+        
+        // signingKey1 should now point to operator2
+        assertEq(
+            newRegistry.getLatestOperatorForSigningKey(signingKey1),
+            operator2Address,
+            "signingKey1 should point to operator2 after reuse"
+        );
+    }
+
     function _sort(
         address[] memory operators,
         bytes[] memory signatures

--- a/test/unit/ECDSAStakeRegistryUnit.t.sol
+++ b/test/unit/ECDSAStakeRegistryUnit.t.sol
@@ -626,23 +626,27 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
 
         ISignatureUtilsMixinTypes.SignatureWithSaltAndExpiry memory operatorSignature;
         address[] memory operators = new address[](30);
+        address[] memory signers = new address[](30);
         bytes[] memory signatures = new bytes[](30);
+        uint256 signer;
         uint8 v;
         bytes32 r;
         bytes32 s;
         for (uint256 i = 1; i < operators.length + 1; i++) {
+            signer = i + 1000;
             operators[i - 1] = address(vm.addr(i));
+            signers[i - 1] = address(vm.addr(signer));
             vm.prank(operators[i - 1]);
-            registry.registerOperatorWithSignature(operatorSignature, operators[i - 1]);
-            (v, r, s) = vm.sign(i, msgHash);
+            registry.registerOperatorWithSignature(operatorSignature, signers[i - 1]);
+            (v, r, s) = vm.sign(signer, msgHash);
             signatures[i - 1] = abi.encodePacked(r, s, v);
         }
-        (operators, signatures) = _sort(operators, signatures);
+        (signers, signatures) = _sort(signers, signatures);
         registry.updateOperators(operators);
         vm.roll(block.number + 1);
         vm.resumeGasMetering();
 
-        registry.isValidSignature(msgHash, abi.encode(operators, signatures, block.number - 1));
+        registry.isValidSignature(msgHash, abi.encode(signers, signatures, block.number - 1));
 
         emit log_named_uint("Gas consumed", before - gasleft());
     }
@@ -709,16 +713,16 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
 
         // Prepare data for signature
         bytes32 dataHash = keccak256("data");
-        address[] memory operators = new address[](1);
-        operators[0] = operator;
+        address[] memory signers = new address[](1);
+        signers[0] = signer; // Use the signing key directly
         bytes[] memory signatures = new bytes[](1);
 
         // Generate signature using the signing key
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, dataHash);
         signatures[0] = abi.encodePacked(r, s, v);
 
-        // Check signatures using the registered signing key
-        registry.isValidSignature(dataHash, abi.encode(operators, signatures, block.number - 1));
+        // Check signatures using the signing key directly
+        registry.isValidSignature(dataHash, abi.encode(signers, signatures, block.number - 1));
     }
 
     function test_WhenUsingSigningKey_CheckSignaturesAtBlock() public {
@@ -735,16 +739,16 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
 
         // Prepare data for signature with initial signing key
         bytes32 dataHash = keccak256("data");
-        address[] memory operators = new address[](1);
-        operators[0] = operator;
+        address[] memory signers = new address[](1);
+        signers[0] = initialSigningKey; // Use the signing key directly
         bytes[] memory signatures = new bytes[](1);
 
         // Generate signature using the initial signing key
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, dataHash);
         signatures[0] = abi.encodePacked(r, s, v);
 
-        // Check signatures using the initial registered signing key
-        registry.isValidSignature(dataHash, abi.encode(operators, signatures, block.number - 1));
+        // Check signatures using the initial signing key directly
+        registry.isValidSignature(dataHash, abi.encode(signers, signatures, block.number - 1));
 
         // Increase block number
         vm.roll(block.number + 10);
@@ -758,8 +762,10 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
         (v, r, s) = vm.sign(signerPk + 1, dataHash);
         signatures[0] = abi.encodePacked(r, s, v);
 
-        // Check signatures using the updated registered signing key
-        registry.isValidSignature(dataHash, abi.encode(operators, signatures, block.number - 1));
+        // Use the updated signing key for verification
+        signers[0] = updatedSigningKey;
+        // Check signatures using the updated signing key directly
+        registry.isValidSignature(dataHash, abi.encode(signers, signatures, block.number - 1));
     }
 
     function test_WhenUsingPriorSigningKey_CheckSignaturesAtBlock() public {
@@ -776,23 +782,24 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
 
         // Prepare data for signature with initial signing key
         bytes32 dataHash = keccak256("data");
-        address[] memory operators = new address[](1);
-        operators[0] = operator;
+        address[] memory signers = new address[](1);
+        signers[0] = initialSigningKey; // Use the signing key directly
         bytes[] memory signatures = new bytes[](1);
 
         // Generate signature using the initial signing key
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, dataHash);
         signatures[0] = abi.encodePacked(r, s, v);
 
-        // Increase block number
+        // Increase block number and store the block we want to reference
+        uint32 referenceBlock = uint32(block.number);
         vm.roll(block.number + 10);
 
         // Update operator's signing key
         vm.prank(operator);
         registry.updateOperatorSigningKey(updatedSigningKey);
 
-        // Check signatures using the initial registered signing key at the previous block
-        registry.isValidSignature(dataHash, abi.encode(operators, signatures, block.number - 10));
+        // Check signatures using the initial signing key at the previous block
+        registry.isValidSignature(dataHash, abi.encode(signers, signatures, referenceBlock));
     }
 
     function test_RevertsWhen_SigningCurrentBlock_IsValidSignature() public {
@@ -803,13 +810,13 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, dataHash);
         bytes memory signature = abi.encodePacked(r, s, v);
-        address[] memory operators = new address[](1);
-        operators[0] = operator;
+        address[] memory signers = new address[](1);
+        signers[0] = signingKey; // Use the signing key directly
         bytes[] memory signatures = new bytes[](1);
         signatures[0] = signature;
 
         vm.expectRevert(abi.encodeWithSignature("InvalidReferenceBlock()"));
-        registry.isValidSignature(dataHash, abi.encode(operators, signatures, currentBlock));
+        registry.isValidSignature(dataHash, abi.encode(signers, signatures, currentBlock));
     }
 
     function test_RevertsWhen_SigningKeyNotValidAtBlock_IsValidSignature() public {
@@ -827,13 +834,13 @@ contract ECDSAStakeRegistryTest is ECDSAStakeRegistrySetup {
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(invalidSignerPk, dataHash);
         bytes memory signature = abi.encodePacked(r, s, v);
-        address[] memory operators = new address[](1);
-        operators[0] = operator;
+        address[] memory signers = new address[](1);
+        signers[0] = updatedSigningKey; // Use the signing key directly
         bytes[] memory signatures = new bytes[](1);
         signatures[0] = signature;
 
-        vm.expectRevert(abi.encodeWithSignature("InvalidSignature()"));
-        registry.isValidSignature(dataHash, abi.encode(operators, signatures, referenceBlock));
+        vm.expectRevert(abi.encodeWithSignature("SignerNotRegistered()"));
+        registry.isValidSignature(dataHash, abi.encode(signers, signatures, referenceBlock));
     }
 
     function test_GetOperatorForSigningKey_AfterRegistration() public {


### PR DESCRIPTION
**Motivation:**

Changes requested in https://github.com/Lay3rLabs/wavs-middleware/pull/120#issuecomment-2912266131

**Modifications:**

isValidSignature takes an array of the signing keys not the operator keys. Store signing key -> operator lookup as well

**Result:**

Easier for wavs software to submit messages when signer != operator